### PR TITLE
Better imports

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,13 +25,14 @@ Database Set Up
 
 from flask.ext.sqlalchemy import SQLAlchemy
 db = SQLAlchemy(app)
-from app.models.flask_security import User, Role
+from app.models import *
 
 """
 Authentication setup
 """
 
-user_datastore = SQLAlchemyUserDatastore(db, User, Role)
+user_datastore = SQLAlchemyUserDatastore(db, flask_security.User,
+    flask_security.Role)
 security = Security(app, user_datastore)
 
 from app.uploader import uploader as uploader_bp

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,17 +1,18 @@
-from base import Base
-from cached_sentences import CachedSentences
-from dependency import Dependency
-from document import Document
-from flask_security import User, Role
-from grammatical_relationship import GrammaticalRelationship
-from project import Project
-from property import Property
-from property_metadata import PropertyMetadata
-from sentence import Sentence
-from sequence import Sequence
-from sets import *
-from unit import Unit
-from word import Word
+from .base import Base
+from .cached_sentences import CachedSentences
+from .dependency import Dependency
+from .document import Document
+from .flask_security import User, Role
+from .grammatical_relationship import GrammaticalRelationship
+from .project import Project
+from .property import Property
+from .property_metadata import PropertyMetadata
+from .sentence import Sentence
+from .sequence import Sequence
+from .sets import *
+from .unit import Unit
+from .word import Word
 
-from association_objects import *
-from association_tables import *
+from .association_objects import *
+from .association_tables import *
+

--- a/app/wordseer/helpers.py
+++ b/app/wordseer/helpers.py
@@ -5,7 +5,9 @@ import pdb
 
 from flask import request
 
-from ..models import *
+from ..models.association_tables import sequences_in_sequencesets
+from ..models.sequence import Sequence
+from ..models.word import Word
 from app import app
 from app import db
 

--- a/tests/testuploader.py
+++ b/tests/testuploader.py
@@ -16,7 +16,15 @@ from sqlalchemy import create_engine
 from app import app as application
 from app import db
 from app import user_datastore
-from app.models import *
+from app.models.document import Document
+from app.models.dependency import Dependency
+from app.models.flask_security import User
+from app.models.property import Property
+from app.models.project import Project
+from app.models.sentence import Sentence
+from app.models.sequence import Sequence
+from app.models.unit import Unit
+from app.models.word import Word
 import database
 
 class TestModels(unittest.TestCase):


### PR DESCRIPTION
Two things have been fixed in this branch:
1. It was not understood why exactly things were working despite the lack of `from app.models import *` in `app/__init__.py`. As it turns out, it worked because another file had the required line in it. 
   
    In this branch, I've placed the `import *` line into `app/__init__.py` and replaced every instance of `import *` (outside of `__init__.py` files) in the code with more specific imports.
   
   This is useful for debugging and for future developers, since they know exactly which modules are available in a given file.
2. Imports now follow [PEP 8](http://legacy.python.org/dev/peps/pep-0008/#imports) more closely. This is a good idea since we are planning to have future programmers work on this code; the closer we keep to established conventions the easier things will be.
