### PR TITLE
Fixed pins according to new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # A Flask-based back end for WordSeer
 
-[![Stories in Ready](https://badge.waffle.io/wordseer/wordseer_flask.png?label=ready&title=Ready)](https://waffle.io/wordseer/wordseer_flask)
-[![Build Status](https://travis-ci.org/Wordseer/wordseer_flask.svg?branch=master)](https://travis-ci.org/Wordseer/wordseer_flask)
-[![Documentation](https://readthedocs.org/projects/wordseer-flask/badge/?version=latest)](http://wordseer-flask.readthedocs.org/en/latest/)
+[![Stories in Ready](https://badge.waffle.io/wordseer/wordseer.png?label=ready&title=Ready)](https://waffle.io/wordseer/wordseer)
+[![Build Status](https://travis-ci.org/Wordseer/wordseer.svg?branch=master)](https://travis-ci.org/Wordseer/wordseer)
+[![Documentation](https://readthedocs.org/projects/wordseer/badge/?version=latest)](http://wordseer.readthedocs.org/en/latest/)
 
 [WordSeer](http://wordseer.berkeley.edu/) is a tool for natural language
 analysis of digital corpora.


### PR DESCRIPTION
README pins have correct URLs now.
